### PR TITLE
fix: 🐛 One Light Theme - Fix Line Number Color

### DIFF
--- a/src/_variables-onelight.scss
+++ b/src/_variables-onelight.scss
@@ -17,5 +17,5 @@ $token-colors: (
 );
 
 $line-numbers: (
-  "number": #A0A3A7
+  "number": #B5B9C2
 );


### PR DESCRIPTION
Changed line number color from #A0A3A7 to #B5B9C2.